### PR TITLE
Feature/hidden settings page fix

### DIFF
--- a/bongo/db/upgrade.php
+++ b/bongo/db/upgrade.php
@@ -38,7 +38,7 @@ if (!defined('MOODLE_INTERNAL')) {
  * @param integer $oldversion
  * @return bool
  */
-function xmldb_mymodule_upgrade($oldversion) {
+function xmldb_bongo_upgrade($oldversion) {
     global $CFG;
 
     $result = true;

--- a/bongo/db/upgrade.php
+++ b/bongo/db/upgrade.php
@@ -47,7 +47,7 @@ function xmldb_bongo_upgrade($oldversion) {
     $result = true;
 
     // Insert PHP code from XMLDB Editor here.
-    if($oldversion < 2018111600){
+    if($oldversion < 2018111601){
 
         // Drop unused field.
         $table = new xmldb_table('bongo');
@@ -74,7 +74,7 @@ function xmldb_bongo_upgrade($oldversion) {
             mod_bongo_insert_dummy_data($bongocourseid);
         }
 
-        upgrade_mod_savepoint(true, 2018111600, 'bongo');
+        upgrade_mod_savepoint(true, 2018111601, 'bongo');
     }
 
     return $result;

--- a/bongo/settings.php
+++ b/bongo/settings.php
@@ -48,6 +48,10 @@ require_once($CFG->dirroot . '/mod/bongo/locallib.php');
 //    }
 //}
 
+$url = new moodle_url('/mod/bongo/index.php');
+$link = html_writer::link($url, get_string('pluginname', 'mod_bongo'));
+$settings->add(new admin_setting_heading('mod_bongo', '', $link));
+
 // Add the Bongo configuration page to the main Admin Tree.
 $ADMIN->add('modsettings',
     new admin_externalpage(
@@ -59,4 +63,4 @@ $ADMIN->add('modsettings',
 );
 
 
-$settings = null;
+//$settings = null;

--- a/bongo/version.php
+++ b/bongo/version.php
@@ -33,7 +33,7 @@ if (!defined('MOODLE_INTERNAL')) {
 }
 
 // YYYYMMDDXX where XX is an incremental counter for the given year.
-$plugin->version = 2018111600;
+$plugin->version = 2018111601;
 
 // Moodle 2.7.0 is required. This is because the mod_lti plugin was not available until 2.7.0.
 $plugin->requires = 2014051200;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "bongo-moodle-plugin",
-  "version": "2018111600",
+  "version": "2018111601",
   "private": false
 }


### PR DESCRIPTION
This will fix the hidden path through the admin pages where you can get a backdoor to Bongo configs. The backdoor previously failed with an error but this change will fix it and point the user to the actual config page.