### PR TITLE
remove db index because it does not need an index for one row

### DIFF
--- a/bongo/db/install.xml
+++ b/bongo/db/install.xml
@@ -26,9 +26,6 @@
                 <KEY NAME="primary" TYPE="primary" FIELDS="id"
                      COMMENT="It is convention to have the ID be the primary key"/>
             </KEYS>
-            <INDEXES>
-                <INDEX NAME="name" UNIQUE="true" FIELDS="name"/>
-            </INDEXES>
         </TABLE>
         <TABLE NAME="bongo_initial_view" COMMENT="Check whether initial view of Bongo config was reached">
             <FIELDS>


### PR DESCRIPTION
Fixes issue #34.  It does not make sense to have an index on the table when there will only be one row in the table.